### PR TITLE
Fix double value not initialized before use

### DIFF
--- a/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
+++ b/packages/syncfusion_flutter_datagrid/lib/src/datagrid_widget/runtime/column.dart
@@ -654,7 +654,7 @@ class ColumnSizer {
         break;
     }
     if (startRowIndex <= 0 && endRowIndex <= 0) {
-      return column._actualWidth;
+      return column._actualWidth.isNaN ? 0 : column._actualWidth;
     }
 
     for (int rowIndex = startRowIndex; rowIndex <= endRowIndex; rowIndex++) {


### PR DESCRIPTION
Returned `double.nan` leads to calling methods use this value instead of calculated column width. So final width was defaulted to 100 pt.

PR suggest to check for nan before return, passing 0 as fallback. This will force use calculated width.